### PR TITLE
Return form as html string to make sure that the order number exists

### DIFF
--- a/KwcShop/Kwc/Shop/Cart/Checkout/Payment/Qenta/ConfirmLink/Component.js
+++ b/KwcShop/Kwc/Shop/Cart/Checkout/Payment/Qenta/ConfirmLink/Component.js
@@ -2,15 +2,14 @@ var onReady = require('kwf/commonjs/on-ready');
 var $ = require('jQuery');
 
 onReady.onRender('.kwcClass', function(el) {
-    var form = el.find('form');
-    form.one('submit', function(e) {
-        e.preventDefault();
+    var buyNowButton = el.find('.kwcBem__buyNowButton');
+    buyNowButton.on('click', function(e) {
         el.find('.kwcBem__process').show();
-        form.hide();
         var config = el.data('options');
         $.post(config.confirmOrderUrl, config.params)
             .done(function (response) {
-                form.submit();
+                buyNowButton.append(response.formHtml);
+                buyNowButton.find('form').submit();
            });
     });
 });

--- a/KwcShop/Kwc/Shop/Cart/Checkout/Payment/Qenta/ConfirmLink/Component.php
+++ b/KwcShop/Kwc/Shop/Cart/Checkout/Payment/Qenta/ConfirmLink/Component.php
@@ -12,10 +12,8 @@ class KwcShop_Kwc_Shop_Cart_Checkout_Payment_Qenta_ConfirmLink_Component extends
     {
         $ret = parent::getTemplateVars($renderer);
         $controllerBaseUrl = Kwc_Admin::getInstance($this->getData()->componentClass)->getControllerUrl();
-        $ret['wirecardButton'] = $this->_getWirecardButton();
         $ret['options'] = array(
             'confirmOrderUrl' => "$controllerBaseUrl/json-confirm-order",
-            'initiatePaymentUrl' => "$controllerBaseUrl/json-initiate-payment",
             'params' => array(
                 'paymentComponentId' => $this->getData()->parent->componentId
             )
@@ -37,8 +35,8 @@ class KwcShop_Kwc_Shop_Cart_Checkout_Payment_Qenta_ConfirmLink_Component extends
             'consumerBillingZipCode' => $order->zip,
             'consumerChallengeIndicator' => '04',
             'merchantTokenizationFlag' => 'true',
-            'orderDescription' => $order->firstname . ' ' . $order->lastname . ' (' . $order->zip . ') '.$payment->trlKwf('Order: {0}', $order->number),
-            'customerStatement' => trl("Bestellung Nr. {$order->number}"), // bank statement
+            'orderDescription' => $order->firstname . ' ' . $order->lastname . ' (' . $order->zip . ') '.$payment->trlKwf('Order: {0}', $order->order_number),
+            'customerStatement' => $payment->trlKwf('Order: {0}', $order->order_number), // bank statement
             'duplicateRequestCheck' => 'no',
             'successUrl' => $payment->getChildComponent('_success')->getAbsoluteUrl(),
             'cancelUrl' => $payment->getChildComponent('_cancel')->getAbsoluteUrl(),
@@ -59,7 +57,6 @@ class KwcShop_Kwc_Shop_Cart_Checkout_Payment_Qenta_ConfirmLink_Component extends
             if ($k == 'secret') continue;
             $ret .= "<input type=\"hidden\" name=\"$k\" value=\"".Kwf_Util_HtmlSpecialChars::filter($i)."\">\n";
         }
-        $ret .= "<input type=\"submit\" value=\"{$payment->trlKwf('Buy now')}\" class=\"submit\">\n";
         $ret .= "</form>\n";
         return $ret;
 

--- a/KwcShop/Kwc/Shop/Cart/Checkout/Payment/Qenta/ConfirmLink/Component.twig
+++ b/KwcShop/Kwc/Shop/Cart/Checkout/Payment/Qenta/ConfirmLink/Component.twig
@@ -1,5 +1,5 @@
 <div class="{{ rootElementClass }}" data-options="{{ options|json_encode }}">
-    {{ wirecardButton|raw }}
+    <div class="{{ 'buyNowButton'|bemClass }}">{{ data.trlKwf('Buy now') }}</div>
     <div class="{{ 'process'|bemClass }}"></div>
     <div class="{{ 'error'|bemClass }}"></div>
 </div>

--- a/KwcShop/Kwc/Shop/Cart/Checkout/Payment/Qenta/ConfirmLink/Controller.php
+++ b/KwcShop/Kwc/Shop/Cart/Checkout/Payment/Qenta/ConfirmLink/Controller.php
@@ -19,6 +19,22 @@ class KwcShop_Kwc_Shop_Cart_Checkout_Payment_Qenta_ConfirmLink_Controller extend
             $order->save();
             $session = new Kwf_Session_Namespace('kwcShopCart');
             $session->qentaCartId = $order->id;
+
+            $confirmLinkCmp = $component->getChildComponent('-confirmLink');
+            $total = $component->parent->getComponent()->getTotal($order);
+            $params = array(
+                'amount' => round($total, 2),
+                'currency' => 'EUR',
+                'paymentType' => Kwc_Abstract::getSetting($component->componentClass, 'paymentType'),
+                'orderId' => $order->id
+            );
+            $this->view->formHtml = call_user_func(array($confirmLinkCmp->componentClass, 'buildWirecardButtonHtml'),
+                $params,
+                $component,
+                $order,
+                Kwf_Config::getValue('qenta.url')
+            );
         }
     }
+
 }


### PR DESCRIPTION
The order number is only created once the submit button is clicked.
Because of this, the order number was previously 0 when the html-form
for the submit button was created. To make sure that the order number
can be sent to qenta, the form is now returned as an html string AFTER
the order status has been set to processing and the order number has
been created.