### PR TITLE
Fix check and assignment of orderId

### DIFF
--- a/KwcShop/Kwc/Shop/Cart/Checkout/Payment/Qenta/Cancel/ContentSender.php
+++ b/KwcShop/Kwc/Shop/Cart/Checkout/Payment/Qenta/Cancel/ContentSender.php
@@ -4,10 +4,13 @@ class KwcShop_Kwc_Shop_Cart_Checkout_Payment_Qenta_Cancel_ContentSender extends 
     public function sendContent($includeMaster)
     {
         $session = new Kwf_Session_Namespace('kwcShopCart');
-        if (!$orderId = $session->qentaCartId && isset($_POST['babytuch_orderId'])) {
+        if ($session->qentaCartId) {
+            $orderId = $session->qentaCartId;
+        } else if (isset($_POST['babytuch_orderId'])) {
             $orderId = $_POST['babytuch_orderId'];
         }
-        if ($orderId) {
+
+        if (isset($orderId)) {
             KwcShop_Kwc_Shop_Cart_Orders::setCartOrderId($orderId);
             $order = Kwf_Model_Abstract::getInstance(Kwc_Abstract::getSetting($this->_data->parent->parent->parent->componentClass, 'childModel'))
                 ->getReferencedModel('Order')->getCartOrder();

--- a/KwcShop/Kwc/Shop/Cart/Checkout/Payment/Qenta/Cancel/ContentSender.php
+++ b/KwcShop/Kwc/Shop/Cart/Checkout/Payment/Qenta/Cancel/ContentSender.php
@@ -6,8 +6,8 @@ class KwcShop_Kwc_Shop_Cart_Checkout_Payment_Qenta_Cancel_ContentSender extends 
         $session = new Kwf_Session_Namespace('kwcShopCart');
         if ($session->qentaCartId) {
             $orderId = $session->qentaCartId;
-        } else if (isset($_POST['babytuch_orderId'])) {
-            $orderId = $_POST['babytuch_orderId'];
+        } else if (isset($_POST['kwcShop_orderId'])) {
+            $orderId = $_POST['kwcShop_orderId'];
         }
 
         if (isset($orderId)) {

--- a/KwcShop/Kwc/Shop/Cart/Checkout/Payment/Qenta/Component.php
+++ b/KwcShop/Kwc/Shop/Cart/Checkout/Payment/Qenta/Component.php
@@ -48,7 +48,7 @@ class KwcShop_Kwc_Shop_Cart_Checkout_Payment_Qenta_Component extends KwcShop_Kwc
             $e->log();
         } else if ($paymentState == 'SUCCESS') {
             $orderRow = Kwf_Model_Abstract::getInstance(Kwc_Abstract::getSetting($this->getData()->parent->parent->componentClass, 'childModel'))
-                ->getReferencedModel('Order')->getRow($qentaResponse['babytuch_orderId']);
+                ->getReferencedModel('Order')->getRow($qentaResponse['kwcShop_orderId']);
 
             if (!$orderRow) {
                 throw new Kwf_Exception("Order not found");

--- a/KwcShop/Kwc/Shop/Cart/Checkout/Payment/Qenta/ConfirmLink/Component.php
+++ b/KwcShop/Kwc/Shop/Cart/Checkout/Payment/Qenta/ConfirmLink/Component.php
@@ -47,7 +47,7 @@ class KwcShop_Kwc_Shop_Cart_Checkout_Payment_Qenta_ConfirmLink_Component extends
             'currency' => $params['currency'],
             'paymentType' => $params['paymentType'],
             'orderReference' => $params['orderId'],
-            'babytuch_orderId' => $order->id
+            'kwcShop_orderId' => $order->id
         );
         $postData['requestFingerprintOrder'] = self::_getRequestFingerprintOrder($postData);
         $postData['requestFingerprint'] = self::_getRequestFingerprint($postData, Kwf_Config::getValue('qenta.secret'));


### PR DESCRIPTION
Previously, orderId would have been a boolean (true) if $session->qentaCartId
was set. This caused a problem with ::setCartOrderId($orderId) which translated
"true" into "1" and getCartOrder() would then return the order with id 1 instead
of the actual order.